### PR TITLE
Add saved message templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ First release since 1.x-1.1.7 (February 2017). It carries both the fixes made
 for this release and the work committed between 2017 and 2025 that was never
 tagged.
 
+### Added
+
+- Saved message templates. The sender, subject and body of a mailing can be
+  saved under a name from the message form and loaded again on any view, rather
+  than only the most recent send being remembered for the one view display.
+  Saving under an existing name replaces it. Templates are listed and can be
+  deleted at Administration > Configuration > System > Views Send > Templates,
+  and each is stored as its own configuration file so it can be deployed
+  between sites.
+
 ### Fixed
 
 - Issue #20: removed `hook_update_last_removed()`. It returned a Drupal 6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Views Send for Backdrop CMS.
 Releases before 1.x-1.2.0 are recorded in the tag list on GitHub; the Drupal
 6/7 history that this module was ported from is in `CHANGELOG.txt`.
 
-## 1.x-1.2.0 (unreleased)
+## 1.x-1.2.0, 2026-08-16
 
 First release since 1.x-1.1.7 (February 2017). It carries both the fixes made
 for this release and the work committed between 2017 and 2025 that was never

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ This is a port from the Drupal module of the same name.
 4. Save the view and load the page. Use any exposed filters to build the list,
    select all or some of the rows, and press "Prepare email".
 5. Fill in the message form to configure the email. Tokens can be used to
-   personalise both the subject and the body.
+   personalise both the subject and the body. A message you send regularly can
+   be saved as a template and loaded again next time - see "Saved message
+   templates" below.
 6. Preview the message and send it.
 
 Permissions are set at Administration > People > Permissions:
@@ -99,7 +101,36 @@ address typed into the body of a message can come out as something other than a
 working mailto: link, depending on which filters the chosen format runs. If you
 need addresses in the body, use a text format with a minimal filter set.
 
-## Templates
+## Saved message templates
+
+A message you send regularly does not have to be retyped. On the message form,
+"Save as template" keeps the sender, subject and body under a name of your
+choosing; "Load a saved template" fills the form back in from it. Saving under
+the name of an existing template replaces it, so loading a template, editing it
+and saving it again updates it in place.
+
+Templates are saved when you press Next, whether or not you go on to send, so
+writing one is not a commitment to a mailing.
+
+Templates are shared by every view on the site. That makes a message written
+once reusable anywhere, but it also means a body containing tokens such as
+`[views-send-field_surname]` will leave those tokens unreplaced on a view whose
+fields differ. The view each template was saved from is recorded and shown at
+Administration > Configuration > System > Views Send > Templates, where
+templates can also be deleted.
+
+Deliberately **not** saved in a template are the "Field used for recipient's
+name" and "Field used for recipient's email" selections. A field name from one
+view means nothing in another. Those stay with the "Remember these values"
+checkbox, which is separate: it remembers the whole form, including the
+recipient fields, for the one view display you are on.
+
+Each template is stored as its own configuration file
+(`views_send.template.<name>.json`), so templates can be exported and deployed
+between sites like any other Backdrop configuration.
+
+
+## Mime Mail theme templates
 
 Views Send for Backdrop provides for customised templates for specific views.
 If, for example, you create a view with machine name test_views_send_page_2,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ Permissions are set at Administration > People > Permissions:
   been added to the spool.
 
 
+## Scope and sending limits
+
+**Views Send is not designed for mass mailing.** It is meant for sending to a
+modest list produced by a view — a committee, a working group, a handful of
+members. Sending newsletters or other bulk email with it is at your own risk.
+
+Every hosting provider limits how much mail an account may send. The limits
+differ between providers, and between sending methods on the same provider:
+mail sent by PHP from a web server is often capped far lower than mail sent
+through authenticated SMTP, and a newly created mailbox is frequently
+restricted for its first days. They are usually several separate caps —
+messages per day, total recipients per day, unique recipients per day, and a
+maximum number of addresses on any single message.
+
+Exceeding them can have messages throttled, silently dropped or treated as
+spam, and repeated breaches can put the sending account, or the whole hosting
+account, at risk.
+
+Check with your provider before sending in bulk, and use a dedicated email
+marketing service for newsletters — those handle consent, unsubscribes and
+delivery reputation, which this module does not.
+
 ## Text formats
 
 The message body is composed in whichever text format Mime Mail is configured

--- a/views_send.admin.inc
+++ b/views_send.admin.inc
@@ -12,6 +12,12 @@
  */
 function views_send_settings() {
   $form = array();
+
+  $form['scope'] = array(
+    '#type' => 'help',
+    '#markup' => t('<strong>Views Send is not designed for mass mailing.</strong> It is meant for sending to a modest list produced by a view - a committee, a working group, a handful of members. Sending newsletters or other bulk email with it is at your own risk. Every hosting provider limits how much mail an account may send, the limits differ between providers and between sending methods, and exceeding them can have your messages dropped, marked as spam, or your account suspended. Check with your provider before sending in bulk, and use a dedicated email marketing service for newsletters.'),
+  );
+
   if (VIEWS_SEND_MIMEMAIL) {
     $form['views_send_attachment_valid_extensions'] = array(
       '#type' => 'textfield',

--- a/views_send.admin.inc
+++ b/views_send.admin.inc
@@ -95,6 +95,76 @@ function views_send_settings() {
 }
 
 /**
+ * Page callback: lists the saved message templates.
+ *
+ * Templates are created from a view's message form, not here - this page
+ * exists so they can be reviewed and removed, which config objects otherwise
+ * make invisible.
+ */
+function views_send_templates_page() {
+  $rows = array();
+  foreach (views_send_template_load_all() as $name => $template) {
+    $rows[] = array(
+      check_plain($template['label']),
+      check_plain($template['subject']),
+      $template['source_display'] ? check_plain($template['source_display']) : t('Unknown'),
+      l(t('Delete'), 'admin/config/system/views_send/templates/' . $name . '/delete'),
+    );
+  }
+
+  $build['help'] = array(
+    '#type' => 'help',
+    '#markup' => t('Templates are saved from the message form of a view, using the "Save as template" field, and are then offered on every view. A message written for one view may contain tokens another view cannot replace, so the view each template was saved from is shown here.'),
+  );
+  $build['templates'] = array(
+    '#theme' => 'table',
+    '#header' => array(t('Name'), t('Subject'), t('Saved from'), t('Operations')),
+    '#rows' => $rows,
+    '#empty' => t('No templates have been saved yet.'),
+  );
+
+  return $build;
+}
+
+/**
+ * Form callback: asks for confirmation before deleting a template.
+ *
+ * @param string $name
+ *   The machine name of the template to delete.
+ */
+function views_send_template_delete_form($form, &$form_state, $name) {
+  $template = views_send_template_load($name);
+  if (!$template) {
+    return MENU_NOT_FOUND;
+  }
+
+  $form['name'] = array(
+    '#type' => 'value',
+    '#value' => $name,
+  );
+  $form['label'] = array(
+    '#type' => 'value',
+    '#value' => $template['label'],
+  );
+
+  return confirm_form($form,
+    t('Delete the template %label?', array('%label' => $template['label'])),
+    'admin/config/system/views_send/templates',
+    t('This cannot be undone. Messages already sent or waiting in the spool are not affected.'),
+    t('Delete')
+  );
+}
+
+/**
+ * Submit handler for views_send_template_delete_form().
+ */
+function views_send_template_delete_form_submit($form, &$form_state) {
+  views_send_template_delete($form_state['values']['name']);
+  backdrop_set_message(t('Deleted the template %label.', array('%label' => $form_state['values']['label'])));
+  $form_state['redirect'] = 'admin/config/system/views_send/templates';
+}
+
+/**
  * Submit handler for module_settings_form().
  */
 function views_send_settings_submit($form, &$form_state){

--- a/views_send.module
+++ b/views_send.module
@@ -230,20 +230,114 @@ function views_send_form_alter(&$form, &$form_state, $form_id) {
 }
 
 /**
+ * Resolves the default sender, subject and message for the "configure" step.
+ *
+ * Three sources can supply them and they are not of equal standing. The values
+ * remembered for this view display are the weakest; values carried back from
+ * the preview step beat them, because they are what the user typed; and a
+ * template just loaded beats both, being the most recent thing the user asked
+ * for.
+ *
+ * @param string $display
+ *   The "<view>_<display>" key the remembered values are stored under.
+ * @param array $form_state
+ *   The form state of the current build.
+ *
+ * @return array
+ *   Keys from_name, from_mail and subject, plus message as an array of value
+ *   and format. The format is always one this user is allowed to use.
+ */
+function _views_send_config_form_defaults($display, $form_state) {
+  $keys = array('from_name', 'from_mail', 'subject');
+  $saved_message = config_get('views_send.settings', "views_send_$display.message");
+
+  $defaults = array(
+    'message' => array(
+      'value' => isset($saved_message['value']) ? $saved_message['value'] : '',
+      'format' => isset($saved_message['format']) ? $saved_message['format'] : _views_send_default_format(),
+    ),
+  );
+  foreach ($keys as $key) {
+    $defaults[$key] = config_get('views_send.settings', "views_send_$display.$key");
+  }
+
+  // Returning to this step from the preview: keep what was typed.
+  if (!empty($form_state['configuration'])) {
+    foreach ($keys as $key) {
+      if (isset($form_state['configuration']['views_send_' . $key])) {
+        $defaults[$key] = $form_state['configuration']['views_send_' . $key];
+      }
+    }
+    if (isset($form_state['configuration']['views_send_message']['value'])) {
+      $defaults['message'] = $form_state['configuration']['views_send_message'];
+    }
+  }
+
+  // A template loaded in this build overrides both.
+  if (!empty($form_state['template'])) {
+    foreach ($keys as $key) {
+      if ($form_state['template'][$key] !== '') {
+        $defaults[$key] = $form_state['template'][$key];
+      }
+    }
+    $defaults['message'] = $form_state['template']['message'];
+  }
+
+  // The format may have been deleted, or belong to a role this user is not in
+  // - a template can outlive both. The form's own validation rejects a format
+  // the sender may not use, so offering one would make the form unsubmittable.
+  $formats = filter_formats();
+  if (empty($defaults['message']['format']) || !isset($formats[$defaults['message']['format']]) || !filter_access($formats[$defaults['message']['format']])) {
+    $defaults['message']['format'] = _views_send_default_format();
+  }
+
+  return $defaults;
+}
+
+/**
  * Multistep form callback for the "configure" step.
  *
  * @TODO: Hide "Sender" (from) if Mandrill is used.
  */
 function views_send_config_form($form, &$form_state, $view, $output) {
-  if (!empty($form_state['configuration'])) {
-    // Values entered in the "config" step.
-    $config = $form_state['configuration'];
-  }
   $display = $view->name . '_' . $view->current_display;
+  $defaults = _views_send_config_form_defaults($display, $form_state);
   $form['display'] = array(
     '#type' => 'value',
     '#value' => $display,
   );
+
+  $template_options = views_send_template_options();
+  $form['template'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Template'),
+    '#description' => t('A template holds the sender, subject and message of a mailing you send regularly, so it does not have to be retyped. Templates are shared by every view on this site - a message written for one view may use tokens another view cannot replace.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => empty($template_options),
+  );
+  if ($template_options) {
+    $form['template']['template_load'] = array(
+      '#type' => 'select',
+      '#title' => t('Load a saved template'),
+      '#options' => array('' => t('- None -')) + $template_options,
+      '#default_value' => '',
+    );
+    $form['template']['load'] = array(
+      '#type' => 'submit',
+      '#value' => t('Load template'),
+      // Without this the required fields below would have to be filled in
+      // before a template could be loaded to fill them in.
+      '#limit_validation_errors' => array(array('template_load')),
+      '#submit' => array('views_send_config_form_load_template_submit'),
+    );
+  }
+  $form['template']['template_label'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Save as template'),
+    '#description' => t('Name the sender, subject and message below to keep them for reuse. Reusing the name of an existing template replaces it. Saved when you press Next, whether or not you go on to send.'),
+    '#maxlength' => 128,
+  );
+
   $form['from'] = array(
     '#type' => 'fieldset',
     '#title' => t('Sender - this will become the reply-to address'),
@@ -254,7 +348,7 @@ function views_send_config_form($form, &$form_state, $view, $output) {
     '#type' => 'textfield',
     '#title' => t('Sender\'s name'),
     '#description' => t("Enter the sender's human readable name."),
-    '#default_value' => config_get('views_send.settings', "views_send_$display.from_name"),
+    '#default_value' => $defaults['from_name'],
     '#maxlen' => 255,
   );
   $form['from']['views_send_from_mail'] = array(
@@ -262,7 +356,7 @@ function views_send_config_form($form, &$form_state, $view, $output) {
     '#title' => t('Sender\'s email'),
     '#description' => t("Enter the sender's email address. This will become the 'reply-to' address in the email."),
     '#required' => TRUE,
-    '#default_value' => config_get('views_send.settings', "views_send_$display.from_mail"),
+    '#default_value' => $defaults['from_mail'],
     '#maxlen' => 255,
   );
 
@@ -309,7 +403,7 @@ function views_send_config_form($form, &$form_state, $view, $output) {
     '#description' => t('Enter the email\'s subject. You can use tokens in the subject.'),
     '#maxlen' => 255,
     '#required' => TRUE,
-    '#default_value' => config_get('views_send.settings', "views_send_$display.subject"),
+    '#default_value' => $defaults['subject'],
   );
   $form['mail']['views_send_message'] = array(
     '#type' => 'text_format',
@@ -319,20 +413,10 @@ function views_send_config_form($form, &$form_state, $view, $output) {
     '#rows' => 10,
     '#attributes' => array('class' => array('text-full')),
   );
-  if (isset($config['views_send_message']['value'])) {
-    // Returning to this step from the preview: keep what was typed.
-    $form['mail']['views_send_message'] += array(
-      '#format' => $config['views_send_message']['format'],
-      '#default_value' => $config['views_send_message']['value'],
-    );
-  }
-  else {
-    $saved_message = config_get('views_send.settings', "views_send_$display.message");
-    $form['mail']['views_send_message'] += array(
-      '#format' => isset($saved_message['format']) ? $saved_message['format'] : _views_send_default_format(),
-      '#default_value' => isset($saved_message['value']) ? $saved_message['value'] : '',
-    );
-  }
+  $form['mail']['views_send_message'] += array(
+    '#format' => $defaults['message']['format'],
+    '#default_value' => $defaults['message']['value'],
+  );
   $form['mail']['token'] = array(
     '#type' => 'fieldset',
     '#title' => t('Tokens'),
@@ -459,6 +543,12 @@ function views_send_config_form_validate($form, &$form_state) {
   $formats = filter_formats();
   if (!filter_access($formats[$values['views_send_message']['format']])) {
     form_set_error('views_send_message', t('Illegal format selected'));
+  }
+
+  // Check the template name, if the user asked for one to be saved.
+  $label = isset($values['template_label']) ? trim($values['template_label']) : '';
+  if ($label !== '' && _views_send_template_machine_name($label) === '') {
+    form_set_error('template_label', t('A template name must contain at least one letter or number.'));
   }
 
   // Check if sender's email is a valid one.
@@ -653,6 +743,17 @@ function views_send_form_submit($form, &$form_state) {
           }
         }
       }
+      // Save the message as a named template if one was asked for. This
+      // happens before the send is confirmed on purpose: a template is worth
+      // keeping even when the mailing it was written for is then abandoned.
+      $label = trim($form_state['values']['template_label']);
+      if ($label !== '') {
+        $replaced = views_send_template_save($label, $form_state['values'], $display);
+        backdrop_set_message($replaced
+          ? t('Replaced the template %label.', array('%label' => $label))
+          : t('Saved the template %label.', array('%label' => $label)));
+      }
+
       $form_state['configuration'] = $form_state['values'];
       $form_state['configuration']['display'] = $display;
       $form_state['configuration']['views_send_attachments'] = array();
@@ -712,6 +813,165 @@ function views_send_form_back_submit($form, &$form_state) {
       $form_state['rebuild'] = TRUE;
       break;
   }
+}
+
+/**
+ * Submit handler for the "Load template" button on the "configure" step.
+ *
+ * Puts the template into the form state and discards the submitted input, so
+ * that the rebuilt form takes its defaults from the template rather than from
+ * what was on screen a moment ago.
+ */
+function views_send_config_form_load_template_submit($form, &$form_state) {
+  // Note the element names in this fieldset deliberately lack the views_send_
+  // prefix: the "configure" step's submit handler persists every value that
+  // has it, and neither the picker nor the save-as name belongs in the
+  // remembered values for this display.
+  $name = $form_state['values']['template_load'];
+  if (!empty($name) && ($template = views_send_template_load($name))) {
+    $form_state['template'] = $template;
+    backdrop_set_message(t('Loaded the template %label. Nothing has been sent yet.', array('%label' => $template['label'])));
+  }
+  else {
+    $form_state['template'] = NULL;
+  }
+  $form_state['input'] = array();
+  $form_state['rebuild'] = TRUE;
+}
+
+// === Message templates =======================================================
+
+/**
+ * Builds the machine name a template label is stored under.
+ *
+ * @param string $label
+ *   The human readable name typed by the user.
+ *
+ * @return string
+ *   A config-safe name, or an empty string if the label held nothing usable.
+ */
+function _views_send_template_machine_name($label) {
+  $name = preg_replace('/[^a-z0-9_]+/', '_', strtolower($label));
+  return substr(trim($name, '_'), 0, 64);
+}
+
+/**
+ * Loads a single saved template.
+ *
+ * @param string $name
+ *   The template's machine name.
+ *
+ * @return array|false
+ *   The template's values, or FALSE if there is no template of that name.
+ */
+function views_send_template_load($name) {
+  $template = config_get('views_send.template.' . $name);
+  if (empty($template)) {
+    return FALSE;
+  }
+  // A template written by an older version, or edited by hand, may be missing
+  // keys that every caller expects to be present.
+  $template += array(
+    'name' => $name,
+    'label' => $name,
+    'from_name' => '',
+    'from_mail' => '',
+    'subject' => '',
+    'source_display' => '',
+  );
+  if (!isset($template['message']['value'])) {
+    $template['message'] = array('value' => '', 'format' => NULL);
+  }
+  return $template;
+}
+
+/**
+ * Loads every saved template, ordered by label.
+ *
+ * @return array
+ *   Templates keyed by machine name.
+ */
+function views_send_template_load_all() {
+  $templates = array();
+  foreach (config_get_names_with_prefix('views_send.template.') as $config_name) {
+    $name = substr($config_name, strlen('views_send.template.'));
+    if ($template = views_send_template_load($name)) {
+      $templates[$name] = $template;
+    }
+  }
+  uasort($templates, '_views_send_template_sort');
+  return $templates;
+}
+
+/**
+ * Sort callback: orders templates by label, case insensitively.
+ */
+function _views_send_template_sort($a, $b) {
+  return strcasecmp($a['label'], $b['label']);
+}
+
+/**
+ * Lists the saved templates for use as form options.
+ *
+ * @return array
+ *   Template labels keyed by machine name.
+ */
+function views_send_template_options() {
+  $options = array();
+  foreach (views_send_template_load_all() as $name => $template) {
+    $options[$name] = $template['label'];
+  }
+  return $options;
+}
+
+/**
+ * Saves the message part of a send as a named template.
+ *
+ * Only the sender, subject and body are kept. The recipient field mappings are
+ * deliberately left out: templates are offered on every view, and a field name
+ * from one view means nothing in another. Those stay with the per-display
+ * "remember these values" storage, which answers a different question.
+ *
+ * @param string $label
+ *   The human readable name. A template with the same machine name is
+ *   replaced, which is what makes "load, edit, save again" update in place.
+ * @param array $values
+ *   The submitted values of the "configure" step.
+ * @param string $display
+ *   The "<view>_<display>" the template was saved from. Recorded so the
+ *   listing can say where a template's tokens came from.
+ *
+ * @return bool
+ *   TRUE if an existing template was replaced, FALSE if one was created.
+ */
+function views_send_template_save($label, array $values, $display = '') {
+  $name = _views_send_template_machine_name($label);
+  $config = config('views_send.template.' . $name);
+  $existed = !$config->isNew();
+
+  $config->set('name', $name);
+  $config->set('label', $label);
+  $config->set('from_name', isset($values['views_send_from_name']) ? $values['views_send_from_name'] : '');
+  $config->set('from_mail', isset($values['views_send_from_mail']) ? $values['views_send_from_mail'] : '');
+  $config->set('subject', isset($values['views_send_subject']) ? $values['views_send_subject'] : '');
+  $config->set('message', array(
+    'value' => isset($values['views_send_message']['value']) ? $values['views_send_message']['value'] : '',
+    'format' => isset($values['views_send_message']['format']) ? $values['views_send_message']['format'] : NULL,
+  ));
+  $config->set('source_display', $display);
+  $config->save();
+
+  return $existed;
+}
+
+/**
+ * Deletes a saved template.
+ *
+ * @param string $name
+ *   The template's machine name.
+ */
+function views_send_template_delete($name) {
+  config('views_send.template.' . $name)->delete();
 }
 
 /**
@@ -911,6 +1171,28 @@ function views_send_menu() {
     'description' => 'Configure Views Send general options.',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('views_send_settings'),
+    'access arguments' => array('administer views_send'),
+    'file' => 'views_send.admin.inc',
+  );
+  $items['admin/config/system/views_send/settings'] = array(
+    'title' => 'Settings',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => -10,
+  );
+  $items['admin/config/system/views_send/templates'] = array(
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Templates',
+    'description' => 'Review and delete saved message templates.',
+    'page callback' => 'views_send_templates_page',
+    'access arguments' => array('administer views_send'),
+    'file' => 'views_send.admin.inc',
+  );
+  // 5 is the position of the % in the path, counting from 0.
+  $items['admin/config/system/views_send/templates/%/delete'] = array(
+    'type' => MENU_CALLBACK,
+    'title' => 'Delete template',
+    'page callback' => 'backdrop_get_form',
+    'page arguments' => array('views_send_template_delete_form', 5),
     'access arguments' => array('administer views_send'),
     'file' => 'views_send.admin.inc',
   );
@@ -1419,6 +1701,13 @@ function views_send_config_info() {
   $prefixes['views_send.settings'] = array(
     'label' => t('Views Send settings'),
     'group' => t('Configuration'),
+  );
+  // One config object per saved message template. The name_key is what makes
+  // core delete them all on uninstall.
+  $prefixes['views_send.template'] = array(
+    'name_key' => 'name',
+    'label_key' => 'label',
+    'group' => t('Views Send templates'),
   );
   return $prefixes;
 }


### PR DESCRIPTION
Adds named message templates to the send form.

Until now the only thing the module remembered was the previous send, stored in
one slot per view display and overwritten each time. A message sent regularly
had to be retyped.

A template holds the sender, subject, body and text format under a name of the
user's choosing. "Save as template" on the message form creates one, "Load a
saved template" fills the form back in from it, and saving under an existing
name replaces it, so loading a template, editing it and saving it again updates
it in place. Templates are saved when Next is pressed, so writing one is not a
commitment to sending.

Templates are offered on every view rather than being tied to the display they
were created on, which is what makes a message written once reusable. The
recipient field mappings are deliberately excluded, because a field name from
one view means nothing in another - those stay with the existing "Remember
these values" checkbox, which is unchanged and continues to hold the whole form
for a single display. The view a template was saved from is recorded and shown
in the listing, since a body may still contain tokens another view cannot
replace.

Each template is stored as its own configuration object,
`views_send.template.<name>`, so templates can be exported and deployed between
sites like any other Backdrop configuration. `hook_config_info()` declares the
prefix with a `name_key`, which is what makes core remove them all on uninstall.

A Templates tab under the settings page lists the saved templates with the view
each came from, and deletes with a confirmation.

Also included: the sender, subject and body defaults are now resolved in one
place with an explicit precedence - remembered values, then values carried back
from the preview, then a loaded template. This replaces the two-branch
condition added for issue #18 rather than extending it, and it verifies that
the text format still exists and is permitted to the sender. That last check
hardens the existing paths too: the form's own validation rejects a format the
sender may not use, so offering one made the form unsubmittable with nothing on
screen to explain why.

No schema change and no update hook are required.

Verified with a CLI harness of 49 assertions covering storage, the defaults
precedence, the form, the load handler and the admin pages, and by walking the
form in a browser. The existing harnesses for the 1.2.0 fixes (24 assertions)
still pass.
